### PR TITLE
Disable plugin by default, allow per-page enabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,21 @@ Create contact forms by writing simple tags.
 
 Download the files.
 
-For [GetSimple CMS], place the `p01-contact` directory and the file `p01-contact_gs.php` in `plugins/`.
+- For [GetSimple CMS], place the `p01-contact` directory and the file `p01-contact_gs.php` in `plugins/`.
 
-For [Pico CMS], place the `p01-contact` directory in `plugins/` and **rename-it `PicoContact`**.
+- For [Pico CMS], place the `p01-contact` directory in `plugins/` and **rename-it `PicoContact`**.
+    The plugin is disabled by default. You can enable it in `config/config.yml`:
+    ~~~
+    PicoContact:
+        enabled: true
+        forall: false # setting this to true will enable the plugin for all pages!
+    ~~~
+    Then you can add
+    ~~~
+    contact:
+        enabled: true
+    ~~~
+    To your contact page's yaml header.
 
 *Compatibility : PHP 5.4+*
 

--- a/p01-contact/.gitignore
+++ b/p01-contact/.gitignore
@@ -1,0 +1,3 @@
+src/pwd
+config.json
+log.json

--- a/p01-contact/PicoContact.php
+++ b/p01-contact/PicoContact.php
@@ -25,7 +25,7 @@ class PicoContact extends AbstractPicoPlugin
 
     protected $doContact = false;
     protected $forAll = false;
-    protected $style = '/plugins/PicoContact/style.css';
+    protected $PicoContactStyle = '/plugins/PicoContact/style.css';
 
     /**
      * Initialize P01contact and set the default language from Pico settings
@@ -56,7 +56,7 @@ class PicoContact extends AbstractPicoPlugin
     {
         if($this->forAll || $meta['contact']['enabled']) {
             $this->doContact = true;
-            if(!empty($meta['contact']['style'])) $this->style=$meta['contact']['style'];
+            if(!empty($meta['contact']['style'])) $this->PicoContactStyle=$meta['contact']['style'];
         }
     }
     /**
@@ -77,7 +77,7 @@ class PicoContact extends AbstractPicoPlugin
             if (!empty($this->default_lang)) {
                 $this->P01contact->default_lang = $this->default_lang;
             }
-            $this->P01contact->style = $this->style;
+            $this->P01contact->PicoContactStyle = $this->PicoContactStyle;
     
             $pwd = $this->generateRandomString();
             file_put_contents(__DIR__ . '/src/pwd',$pwd);

--- a/p01-contact/PicoContact.php
+++ b/p01-contact/PicoContact.php
@@ -54,7 +54,7 @@ class PicoContact extends AbstractPicoPlugin
     }
     public function onMetaParsed(array &$meta)
     {
-        if($this->forAll || ( !empty($meta['contact']['enabled']) && $meta['contact']['enabled'] ) {
+        if($this->forAll || (!empty($meta['contact']['enabled']) && $meta['contact']['enabled']) ) {
             $this->doContact = true;
             if(!empty($meta['contact']['style'])) $this->ContactStyle=$meta['contact']['style'];
         }

--- a/p01-contact/PicoContact.php
+++ b/p01-contact/PicoContact.php
@@ -25,7 +25,7 @@ class PicoContact extends AbstractPicoPlugin
 
     protected $doContact = false;
     protected $forAll = false;
-    protected $PicoContactStyle = '/plugins/PicoContact/style.css';
+    protected $ContactStyle = '/plugins/PicoContact/style.css';
 
     /**
      * Initialize P01contact and set the default language from Pico settings
@@ -56,7 +56,7 @@ class PicoContact extends AbstractPicoPlugin
     {
         if($this->forAll || $meta['contact']['enabled']) {
             $this->doContact = true;
-            if(!empty($meta['contact']['style'])) $this->PicoContactStyle=$meta['contact']['style'];
+            if(!empty($meta['contact']['style'])) $this->ContactStyle=$meta['contact']['style'];
         }
     }
     /**
@@ -77,7 +77,7 @@ class PicoContact extends AbstractPicoPlugin
             if (!empty($this->default_lang)) {
                 $this->P01contact->default_lang = $this->default_lang;
             }
-            $this->P01contact->PicoContactStyle = $this->PicoContactStyle;
+            $this->P01contact->ContactStyle = $this->ContactStyle;
     
             $pwd = $this->generateRandomString();
             file_put_contents(__DIR__ . '/src/pwd',$pwd);

--- a/p01-contact/PicoContact.php
+++ b/p01-contact/PicoContact.php
@@ -54,7 +54,7 @@ class PicoContact extends AbstractPicoPlugin
     }
     public function onMetaParsed(array &$meta)
     {
-        if($this->forAll || $meta['contact']['enabled']) {
+        if($this->forAll || ( !empty($meta['contact']['enabled']) && $meta['contact']['enabled'] ) {
             $this->doContact = true;
             if(!empty($meta['contact']['style'])) $this->ContactStyle=$meta['contact']['style'];
         }

--- a/p01-contact/PicoContact.php
+++ b/p01-contact/PicoContact.php
@@ -21,6 +21,8 @@ class PicoContact extends AbstractPicoPlugin
 
     private $P01contact;
 
+    protected $enabled = false;
+    
     /**
      * Initialize P01contact and set the default language from Pico settings
      *

--- a/p01-contact/src/P01contact.php
+++ b/p01-contact/src/P01contact.php
@@ -112,7 +112,8 @@ class P01contact
         $defaultStyle = '';
         static $once;
         if (!$once) {
-            $defaultStyle = '<link rel="stylesheet" href="'.SERVER.RELPATH.'style.css"/>';
+            if (empty($this->ContactStyle)) $this->ContactStyle=SERVER.RELPATH."style.css";
+            $defaultStyle = '<link rel="stylesheet" href="'.$this->ContactStyle.'"/>';
             $once = true;
         }
         $form = new P01contactForm($this);


### PR DESCRIPTION
PicoContact is enabled by default and sets a PHP session cookie and some undesirable headers for all pages:
~~~
Set-Cookie: PHPSESSID=ffmljcpgvdg3mqoeu4bpthavbk; path=/
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
~~~
I created this fork to disable this behaviour. See also #56.

With this version the plugin is disabled by default, can be enabled in `config/*.yml` and activated only on the desired contact page(s). See README.md.

I also added a `.gitignore` to ignore user configuration and temporary files.

I haven't touched any other files because I don't know how GetSimple works.